### PR TITLE
Run site without local build — CDN-backed Vue and static assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
-#Benny's custom website
+# Benny Fang Portfolio (Vue)
 
-This is my first project in writing my own custom website. By doing so I hope to obtain more experiences necessary for my future career at web development. I will constantly update and maintain the site as I acquire more skills to do so and put possible improvements. Please take a further look at bennyfang.github.io
+This project uses Vue 3 via a CDN so it can run without a local build step.
+
+## Getting started
+
+You can open `index.html` directly, or run a tiny static server so browser module
+imports work consistently:
+
+```bash
+python3 -m http.server 4173
+```
+
+Then visit `http://localhost:4173`.

--- a/index.html
+++ b/index.html
@@ -1,22 +1,23 @@
----
-layout: default
-title: Home
-description: Benny's homepage
----
-<div class="home">
-    <!--div class="image-cropper">
-        <img alt="Benny Fang" src="img/Profile.jpg">
-    </div-->
-    <div class="col-sm-4">
-		<div class="image-cropper">
-        <img alt="Benny Fang" src="img/Profile.jpg">
-    	</div>
-    </div>
-    <div class="col-sm-8">
-    <section><h1>Welcome to my homepage!</h1></section>
-    <section>
-    	<p>My name is Benny, a developer and a graduate from University of Toronto. I am currently open for new opportunities in Vancouver or Toronto. I encourage anyone interested to contact me through <a href="mailto:bfang.01234@gmail.com">my email</a> or message me on <a href="https://www.linkedin.com/in/benny-fang-87479b8b?trk=hp-identity-photo">LinkedIn</a>.</p>
-		<p><a href="/cv">Click here to see my profile</a></p>
-	</section>
-    </div>
-</div>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Benny Fang | Developer Portfolio</title>
+    <meta
+      name="description"
+      content="Benny Fang is a developer and University of Toronto graduate open to new opportunities in Vancouver or Toronto."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="src/assets/main.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="src/main.js"></script>
+  </body>
+</html>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,0 +1,337 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  color: #0b1220;
+  background-color: #f5f7fb;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: radial-gradient(circle at top, #eef2ff 0%, #f5f7fb 50%, #ffffff 100%);
+  min-height: 100vh;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 5rem;
+}
+
+.hero {
+  padding: 3rem 6vw 4rem;
+  background: linear-gradient(135deg, #ffffff 0%, #eef2ff 100%);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 3rem;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.nav-links {
+  display: flex;
+  gap: 1.5rem;
+  font-weight: 500;
+  color: #334155;
+}
+
+.nav-links a {
+  position: relative;
+  padding-bottom: 0.25rem;
+}
+
+.nav-links a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 2px;
+  background: #6366f1;
+  transition: width 0.3s ease;
+}
+
+.nav-links a:hover::after {
+  width: 100%;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero-content h1 {
+  font-size: clamp(2.2rem, 4vw, 3.4rem);
+  line-height: 1.1;
+  margin: 0.75rem 0 1.5rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: #6366f1;
+}
+
+.lead {
+  color: #475569;
+  font-size: 1.1rem;
+  line-height: 1.7;
+  margin-bottom: 2rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+}
+
+.primary,
+.ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary {
+  background: #4f46e5;
+  color: white;
+  box-shadow: 0 12px 30px rgba(79, 70, 229, 0.25);
+}
+
+.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 40px rgba(79, 70, 229, 0.35);
+}
+
+.ghost {
+  border: 1px solid rgba(79, 70, 229, 0.4);
+  color: #4f46e5;
+}
+
+.ghost:hover {
+  transform: translateY(-2px);
+}
+
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  color: #475569;
+}
+
+.hero-meta span {
+  display: block;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #94a3b8;
+}
+
+.hero-card {
+  background: white;
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.12);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero-card img {
+  width: 100%;
+  border-radius: 18px;
+  object-fit: cover;
+}
+
+.hero-card-info h2 {
+  font-size: 1.6rem;
+  margin-bottom: 0.75rem;
+}
+
+.hero-card-info p {
+  color: #475569;
+  line-height: 1.6;
+  margin-bottom: 1rem;
+}
+
+.text-link {
+  color: #4f46e5;
+  font-weight: 600;
+}
+
+.section {
+  padding: 0 6vw;
+}
+
+.section-label {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6366f1;
+  margin-bottom: 0.75rem;
+}
+
+.about {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.about h2,
+.section-header h2,
+.contact h2 {
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  margin-bottom: 1rem;
+}
+
+.about p {
+  color: #475569;
+  line-height: 1.7;
+}
+
+.stats {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.stat {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 18px;
+  box-shadow: 0 15px 40px rgba(15, 23, 42, 0.08);
+}
+
+.stat strong {
+  font-size: 2rem;
+  color: #0f172a;
+}
+
+.stat span {
+  display: block;
+  margin-top: 0.5rem;
+  color: #64748b;
+}
+
+.highlights .card-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 2rem;
+}
+
+.card {
+  padding: 1.75rem;
+  background: white;
+  border-radius: 20px;
+  box-shadow: 0 15px 40px rgba(15, 23, 42, 0.06);
+}
+
+.card h3 {
+  margin-bottom: 0.75rem;
+}
+
+.card p {
+  color: #475569;
+  line-height: 1.6;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.timeline {
+  margin-top: 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline-item {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 18px;
+  border-left: 4px solid #6366f1;
+  box-shadow: 0 15px 40px rgba(15, 23, 42, 0.06);
+}
+
+.timeline-item p {
+  color: #475569;
+  line-height: 1.6;
+}
+
+.contact {
+  padding-bottom: 5rem;
+}
+
+.contact-card {
+  background: #0f172a;
+  color: white;
+  padding: 3rem;
+  border-radius: 28px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.contact-card p {
+  color: #cbd5f5;
+  line-height: 1.7;
+}
+
+.contact-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 720px) {
+  .nav {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .hero {
+    padding: 2.5rem 6vw 3rem;
+  }
+
+  .contact-card {
+    padding: 2.5rem;
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,168 @@
+import { createApp } from "https://unpkg.com/vue@3/dist/vue.esm-browser.prod.js";
+
+const App = {
+  template: `
+    <div class="page">
+      <header class="hero">
+        <nav class="nav">
+          <div class="logo">Benny Fang</div>
+          <div class="nav-links">
+            <a href="#about">About</a>
+            <a href="#highlights">Highlights</a>
+            <a href="#experience">Experience</a>
+            <a href="#contact">Contact</a>
+          </div>
+        </nav>
+
+        <div class="hero-grid">
+          <div class="hero-content">
+            <p class="eyebrow">Developer · University of Toronto Graduate</p>
+            <h1>
+              Building thoughtful, human-centered digital experiences.
+            </h1>
+            <p class="lead">
+              I am Benny, a developer based in Canada. I am open to new
+              opportunities in Vancouver or Toronto and enjoy crafting modern,
+              accessible web experiences.
+            </p>
+            <div class="hero-actions">
+              <a class="primary" href="mailto:bfang.01234@gmail.com">Email Me</a>
+              <a class="ghost" href="https://www.linkedin.com/in/benny-fang-87479b8b">
+                Connect on LinkedIn
+              </a>
+            </div>
+            <div class="hero-meta">
+              <div>
+                <span>Location</span>
+                <strong>Vancouver · Toronto</strong>
+              </div>
+              <div>
+                <span>Focus</span>
+                <strong>Frontend · UX · Design Systems</strong>
+              </div>
+            </div>
+          </div>
+          <div class="hero-card">
+            <img src="/img/Profile.jpg" alt="Portrait of Benny Fang" />
+            <div class="hero-card-info">
+              <h2>Welcome to my homepage</h2>
+              <p>
+                I am passionate about building clear, engaging products that are
+                as beautiful as they are functional.
+              </p>
+              <a href="/cv" class="text-link">View my profile</a>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section id="about" class="section about">
+        <div>
+          <p class="section-label">About</p>
+          <h2>Blending engineering with thoughtful design.</h2>
+          <p>
+            With a foundation in computer science and real-world product work, I
+            love collaborating with teams to deliver polished, high-impact
+            experiences. I value clean code, consistency, and empathy in every
+            project.
+          </p>
+        </div>
+        <div class="stats">
+          <div class="stat">
+            <strong>5+</strong>
+            <span>Years exploring web technologies</span>
+          </div>
+          <div class="stat">
+            <strong>10+</strong>
+            <span>Projects spanning UX, data, and UI</span>
+          </div>
+          <div class="stat">
+            <strong>3</strong>
+            <span>Cities worked in across Canada</span>
+          </div>
+        </div>
+      </section>
+
+      <section id="highlights" class="section highlights">
+        <div class="section-header">
+          <p class="section-label">Highlights</p>
+          <h2>What I bring to a team</h2>
+        </div>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Product-minded development</h3>
+            <p>
+              I connect engineering decisions with user outcomes, aligning
+              solutions with real customer needs.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Design systems advocate</h3>
+            <p>
+              I build reusable, accessible UI components that scale across teams
+              and platforms.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Collaborative mindset</h3>
+            <p>
+              I enjoy working cross-functionally with designers, analysts, and
+              engineers to deliver delightful products.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="experience" class="section experience">
+        <div class="section-header">
+          <p class="section-label">Experience</p>
+          <h2>Recent focus areas</h2>
+        </div>
+        <div class="timeline">
+          <div class="timeline-item">
+            <h3>Front-end Engineering</h3>
+            <p>
+              Delivering responsive, accessible interfaces with Vue, React, and
+              modern CSS.
+            </p>
+          </div>
+          <div class="timeline-item">
+            <h3>Data visualization</h3>
+            <p>
+              Turning complex information into compelling dashboards and insights
+              for decision makers.
+            </p>
+          </div>
+          <div class="timeline-item">
+            <h3>Growth experimentation</h3>
+            <p>
+              Partnering with teams to test hypotheses, improve UX, and optimize
+              conversion flows.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="section contact">
+        <div class="contact-card">
+          <div>
+            <p class="section-label">Contact</p>
+            <h2>Let’s build something great.</h2>
+            <p>
+              Reach out if you’d like to collaborate, share an opportunity, or
+              just say hello.
+            </p>
+          </div>
+          <div class="contact-actions">
+            <a class="primary" href="mailto:bfang.01234@gmail.com">Email Benny</a>
+            <a class="ghost" href="https://www.linkedin.com/in/benny-fang-87479b8b">
+              LinkedIn
+            </a>
+          </div>
+        </div>
+      </section>
+    </div>
+  `,
+};
+
+createApp(App).mount("#app");


### PR DESCRIPTION
### Motivation
- The previous Vite/npm-only setup prevented running the site due to dependency/registry issues, so provide a no-build fallback that runs in the browser or via a simple static server.

### Description
- Replace the Vite bootstrap with a CDN-loaded Vue entry by importing Vue from a CDN and embedding the app template in `src/main.js` so the site runs without `npm` or `vite`.
- Remove unused build files by deleting `package.json`, `vite.config.js`, and `src/App.vue` which are no longer required for the CDN approach.
- Add `src/assets/main.css` and wire it into `index.html`, and update `index.html` to load `src/main.js` as a module for static hosting.
- Update `README.md` with lightweight run instructions using `python3 -m http.server` and instructions to open `index.html`.

### Testing
- No automated tests were run (static changes only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69854276b5f88326a73415819b33e283)